### PR TITLE
feat: more flexible terminal display options

### DIFF
--- a/doc/sniprun.txt
+++ b/doc/sniprun.txt
@@ -103,6 +103,9 @@ require'sniprun'.setup({
   live_display = { "VirtualTextOk" }, --# display mode used in live_mode
 
   display_options = {
+    terminal_scrollback = vim.o.scrollback, -- change terminal display scrollback lines
+    terminal_line_number = false, -- whether show line number in terminal window
+    terminal_signcolumn = false, -- whether show signcolumn in terminal window
     terminal_width = 45,       --# change the terminal display option width
     notification_timeout = 5   --# timeout for nvim_notify output
   },

--- a/doc/sources/README.md
+++ b/doc/sources/README.md
@@ -251,6 +251,9 @@ require'sniprun'.setup({
   live_display = { "VirtualTextOk" }, --# display mode used in live_mode
 
   display_options = {
+    terminal_scrollback = vim.o.scrollback, -- change terminal display scrollback lines
+    terminal_line_number = false, -- whether show line number in terminal window
+    terminal_signcolumn = false, -- whether show signcolumn in terminal window
     terminal_width = 45,       --# change the terminal display option width
     notification_timeout = 5   --# timeout for nvim_notify output
   },

--- a/doc/sources/display_modes.md
+++ b/doc/sources/display_modes.md
@@ -125,6 +125,9 @@ lua << EOF
 require'sniprun'.setup({
     display = { "Terminal" },
     display_options = {
+        terminal_scrollback = vim.o.scrollback, -- change terminal display scrollback lines
+        terminal_line_number = false, -- whether show line number in terminal window
+        terminal_signcolumn = false, -- whether show signcolumn in terminal window
         terminal_width = 45,
     },
 })

--- a/lua/sniprun.lua
+++ b/lua/sniprun.lua
@@ -35,6 +35,9 @@ M.config_values = {
   live_display = { "VirtualTextOk" }, -- displayed only for live mode
 
   display_options = {
+    terminal_scrollback = vim.o.scrollback, -- change terminal display scrollback lines
+    terminal_line_number = false, -- whether show line number in terminal window
+    terminal_signcolumn = false, -- whether show signcolumn in terminal window
     terminal_width = 45,       -- change the terminal display option width
     notification_timeout = 5   -- timeout for nvim_notify output
   },
@@ -80,6 +83,8 @@ end
 
 function M.setup(opts)
   opts = opts or {}
+
+  -- pre-process config keys
   for key,value in pairs(opts) do
     if M.config_values[key] == nil then
       error(string.format('[Sniprun] Key %s does not exist in config values',key))
@@ -91,8 +96,11 @@ function M.setup(opts)
     if key == 'live_mode_toggle' and opts[key] == 'enable' then
       require('sniprun.live_mode')
     end
-    M.config_values[key] = value
   end
+
+  -- merge user config into default config values
+  M.config_values = vim.tbl_deep_extend("force", M.config_values, opts)
+
   M.configure_keymaps()
   M.setup_highlights()
   M.setup_autocommands()

--- a/ressources/display_terminal.md
+++ b/ressources/display_terminal.md
@@ -26,6 +26,9 @@ EOF
 You can change the width of the terminal by using the display option in the configuration:
 ```
   display_options = {
+    terminal_scrollback = vim.o.scrollback, -- change terminal display scrollback lines
+    terminal_line_number = false, -- whether show line number in terminal window
+    terminal_signcolumn = false, -- whether show signcolumn in terminal window
     terminal_width = 45,       -- change the terminal display option width
   },
 ```


### PR DESCRIPTION
This commit enhance Sniprun configurations with following changes:

1. Allows to merge user options into default config_values key by key. Consider below situation:

```lua
-- config_values
{ display_options = { terminal_width = 45, notification_timeout = 5 } }

-- user options
{ display_options = { terminal_scrollback = 1 } }

-- previous behavior result:
--   overrides display_options and lost default options
{ display_options = { terminal_scrollback = 1 } }

-- new behavior result:
--   merge into default options
{ display_options = { terminal_wdith = 45, notification_timeout = 5, terminal_scrollback = 1 } }
```

   This is implemented with `vim.tbl_deep_extend("force", M.config_values, opts)`.

2. Sets local non-intrusive scrollback option in terminal buffer. Previous implementation `set scrollback=1` changes scrollback globally, which affects non-sniprun terminals.

3. Adds 3 new display options: `terminal_scrollback`, `terminal_line_number` and `terminal_signcolumn`.