### PR TITLE
Update install.sh to show the error msg when build failed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ force_build=$1
 cargo_build() {
   if command -v cargo >/dev/null; then
     echo "Building sniprun from source..."
-    cargo build --release &>/dev/null
+    cargo build --release 2>&1
     echo "Done (status: $?)"
     return 0
   else


### PR DESCRIPTION
When I build this by LazyVim, there's no error show but the binary didn't build successfully

And when I tried to build the binary from source, the outcome is like:

```
Runnning Sniprun Installer
Looks you are not running Linux: Mac users have to compile sniprun themselves and thus need the Rust toolchain
Compiling sniprun locally:
Building sniprun from source...
Done (status: 101)
```

even thought the status was 101 which indicated that there's something wrong.But not very clear.

So I think it's better to print out the error msg out to give more information when install failed.

Like in my case:

```
❯ bash install.sh
Runnning Sniprun Installer
Looks you are not running Linux: Mac users have to compile sniprun themselves and thus need the Rust toolchain
Compiling sniprun locally:
Building sniprun from source...
    Updating crates.io index
error: failed to download from `https://crates.io/api/v1/crates/aho-corasick/1.0.1/download`

Caused by:
  [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: unable to get local issuer certificate)
Done (status: 101)
```

I could easily know the reason~