### PR TITLE
Making install script more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sniprun is a code runner plugin for neovim written in Lua and Rust. It aims to p
 
 </br>
 
-TLDR: `Plug 'michaelb/sniprun', {'do': 'bash install.sh'}`, `:SnipRun`, `:'<,'>SnipRun`, `:SnipInfo`
+TLDR: `Plug 'michaelb/sniprun', {'do': 'sh install.sh'}`, `:SnipRun`, `:'<,'>SnipRun`, `:SnipInfo`
 
 # Installation, configuration, ...
 
@@ -82,7 +82,8 @@ Due to its nature, Sniprun may have trouble with programs that :
 - Mess with standard output / stderr
 - Need to read from stdin
 - Access files; sniprun does not run in a virtual environment, it accesses files just like your own code do, but since it does not run the whole program, something might go wrong. **Relative paths may cause issues**, as the current working directory for sniprun will be somewhere in ~/.cache/sniprun, and relative imports may miss.
-- No support for Windows, and NixOS or MacOS users have to compile sniprun locally.
+- No support for Windows
+- Users of other Unixes have to compile sniprun locally.
 
 ## Changelog
 

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,13 @@
-#!/usr/bin/env bash
-
+#!/bin/sh
 
 echo "Runnning Sniprun Installer"
-local_version=v$(cat Cargo.toml | grep ^version | cut -d "\"" -f 2)
-name="sniprun"
+local_version="v$(grep ^version Cargo.toml | cut -d "\"" -f 2)"
 force_build=$1
 
 cargo_build() {
   if command -v cargo >/dev/null; then
     echo "Building sniprun from source..."
-    cargo build --release &>/dev/null
+    cargo build --release 2>&1
     echo "Done (status: $?)"
     return 0
   else
@@ -24,35 +22,35 @@ get_latest_release() {
 
 # download the sniprun binary (of the specified version) from Releases
 download() {
-  echo "Downloading sniprun binary: " $1
-  curl -fsSL https://github.com/michaelb/sniprun/releases/download/$1/sniprun --output sniprun
+  echo "Downloading sniprun binary: $1"
+  curl -fsSL "https://github.com/michaelb/sniprun/releases/download/$1/sniprun" --output sniprun
   mkdir -p target/release/
   mv -f sniprun target/release/
 }
 
 # call download, make executable, and return status
 fetch_prebuilt_binary() {
-  if (download $1); then
+  if (download "$1"); then
     chmod a+x target/release/sniprun
     echo "Done"
-    return 0 
+    return 0
   else
     return 1
   fi
 }
 
 arch=$(uname)
-if [[ $arch != "Linux" && $force_build != 1 ]]; then
+if [ "$arch" != "Linux" ] && [ "$force_build" != 1 ]; then
   echo "Looks you are not running Linux: Mac users have to compile sniprun themselves and thus need the Rust toolchain"
   force_build=1
 fi
 
 remote_version=$(get_latest_release)
 
-if [ $force_build ]; then
+if [ "$force_build" ]; then
   echo "Compiling sniprun locally:"
   neovim_version=$(nvim --version | head -n 1 | cut -d . -f 2) # 4 -> neovim 0.4.x
-  if [ $neovim_version == "4" ]; then
+  if [ "$neovim_version" = "4" ]; then
     echo "Sniprun 0.4.9 is the highest version supported on neovim 0.4.x"
     git reset --hard v0.4.9
   fi
@@ -61,19 +59,16 @@ else
 
   tag_to_fetch=$remote_version
   neovim_version=$(nvim --version | head -n 1 | cut -d . -f 2) # 4 -> neovim 0.4.x
-  if [ $neovim_version == "4" ]; then
+  if [ "$neovim_version" = "4" ]; then
     echo "Sniprun 0.4.9 is the highest version supported on neovim 0.4.x"
     git reset --hard v0.4.9
     tag_to_fetch="v0.4.9"
   fi
 
-  fetch_prebuilt_binary $tag_to_fetch
-  success=$?
+  fetch_prebuilt_binary "$tag_to_fetch"
 
   # if download failed
-  if [ $success == 1 ]; then
+  if [ $? = 1 ]; then
     echo "Failed to download sniprun, check your network or build locally?"
   fi
 fi
-
-


### PR DESCRIPTION
Hi,
This PR tries to make the install script more robust, and more portable to other system other than mainstream Linux distros.

Changes:
* The script is now POSIX compliant. This means that runs without problems on all those system that either don't have bash installed or has a very outdated version (e.g. MacOS, BSD, Alpine, etc).
* Fix some shell scripting errors
* Adds some shell scripting best practices
* Better logging by showing error code in che echoed message