### PR TITLE
Fix release tag detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ cargo_build() {
 }
 
 get_latest_release() {
-  curl --silent "https://api.github.com/repos/michaelb/sniprun/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' # Pluck JSON value
+  curl --silent "https://api.github.com/repos/michaelb/sniprun/releases/latest" | LC_ALL=C tr -d "\n" | sed -e 's|^.*\("tag_name".*\)|\1|' | cut -d'"' -f4 # Pluck JSON value
 }
 
 # download the sniprun binary (of the specified version) from Releases


### PR DESCRIPTION
Without this fix it currently becomes

    tag_to_fetch='This release and associated artifacts were created by Github Action. See the changelog [here](https://github.com/michaelb/sniprun/blob/master/CHANGELOG.md).'