### PR TITLE
ressources: use \cat instead of /bin/cat in scripts

### DIFF
--- a/ressources/init_repl.sh
+++ b/ressources/init_repl.sh
@@ -35,7 +35,7 @@ mkfifo $working_dir/$pipe
 touch $working_dir/$out
 sleep 36000 > $working_dir/$pipe &
 
-echo "/bin/cat " $working_dir/$pipe " | " $repl  > $working_dir/real_launcher.sh
+echo "\cat " $working_dir/$pipe " | " $repl  > $working_dir/real_launcher.sh
 chmod +x $working_dir/real_launcher.sh
 
 echo $repl " process started at $(date +"%F %T")." >> $log

--- a/ressources/launcher_repl.sh
+++ b/ressources/launcher_repl.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/bin/cat $1 > $2
+\cat $1 > $2


### PR DESCRIPTION
The current scripts (`init_repl.sh` and `launcher_repl.sh`) expect `cat` to be available in `/bin`.
This is not the case for all systems.
This patch switches to `\cat` which accomplishes the same goal of ignoring user-defined shell aliases of the `cat` command.