### PR TITLE
fix compiler flags support of Cpp_original

### DIFF
--- a/src/interpreters/Cpp_original.rs
+++ b/src/interpreters/Cpp_original.rs
@@ -153,7 +153,8 @@ impl Interpreter for Cpp_original {
         let mut _file =
             File::create(&self.main_file_path).expect("Failed to create file for rust-original");
         write(&self.main_file_path, &self.code).expect("Unable to write to file for rust-original");
-        let output = Command::new(&self.compiler)
+        let output = Command::new(self.compiler.split_whitespace().next().unwrap())
+            .args(self.compiler.split_whitespace().skip(1))
             .arg(&self.main_file_path)
             .arg("-o")
             .arg(&self.bin_path)


### PR DESCRIPTION
When using custom compiler with flags (say: clang++ --debug), "Command::new()" was unable to start process, giving an error message "No such file or directory".