### PR TITLE
Update Cargo.lock sniprun version to 1.3.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,7 +795,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sniprun"
-version = "1.3.14-beta"
+version = "1.3.14"
 dependencies = [
  "close_fds",
  "dirs",


### PR DESCRIPTION
Update Cargo.lock sniprun version to 1.3.14