### PR TITLE
Fix: correct string comparison operator for compatibility with sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ local_version="v$(grep ^version Cargo.toml | cut -d "\"" -f 2)"
 
 force_build=$1
 current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" == "dev" ]; then
+if [ "$current_branch" = "dev" ]; then
   force_build=1
 fi
 


### PR DESCRIPTION
The previous script used '==' for string comparison when checking if `install.sh` runs from dev branch, which is not compatible with 'sh'.

Changed to use '=' for maximum compatibility across different shells.