### PR TITLE
Add compiler option to Typescript

### DIFF
--- a/doc/sources/interpreters/TypeScript_original.md
+++ b/doc/sources/interpreters/TypeScript_original.md
@@ -1,5 +1,23 @@
 ## TypeScript original
 
-Requires `ts-node`, usually installed from npm
+Prior to NodeJS v22.6.0:
+Install `ts-node`, usually installed from npm
 
 `sudo npm install -g ts-node typescript`
+
+---
+
+If you have NodeJS v22.6.0+:
+
+```lua
+require'sniprun'.setup({
+    interpreter_options = {
+        TypeScript_original = {
+            compiler = 'node'
+            }
+        }
+    }
+})
+```
+
+[^1]: `ts-node` and `typescript` packages are no longer needed for newer NodeJS versions

--- a/doc/sources/interpreters/TypeScript_original.md
+++ b/doc/sources/interpreters/TypeScript_original.md
@@ -13,7 +13,7 @@ If you have NodeJS v22.6.0+:
 require'sniprun'.setup({
     interpreter_options = {
         TypeScript_original = {
-            compiler = 'node'
+            interpreter = 'node'
             }
         }
     }

--- a/src/interpreters/TypeScript_original.rs
+++ b/src/interpreters/TypeScript_original.rs
@@ -28,7 +28,7 @@ impl Interpreter for TypeScript_original {
         let mfp = lwd + "/main.ts";
 
         let interpreter = match TypeScript_original::get_interpreter_option(&data, "interpreter") {
-            Some(user_compiler) => user_compiler.to_string().replace("\"", ""),
+            Some(user_interpreter) => user_interpreter.to_string().replace("\"", ""),
             None => "ts-node".to_string()
         };
         Box::new(TypeScript_original {

--- a/src/interpreters/TypeScript_original.rs
+++ b/src/interpreters/TypeScript_original.rs
@@ -9,7 +9,7 @@ pub struct TypeScript_original {
     main_file_path: String,
 
     //specific to Typescript
-    compiler: String,
+    interpreter: String,
 }
 
 impl ReplLikeInterpreter for TypeScript_original {}
@@ -27,7 +27,7 @@ impl Interpreter for TypeScript_original {
         //pre-create string pointing to main file's and binary's path
         let mfp = lwd + "/main.ts";
 
-        let compiler = match TypeScript_original::get_interpreter_option(&data, "compiler") {
+        let interpreter = match TypeScript_original::get_interpreter_option(&data, "interpreter") {
             Some(user_compiler) => user_compiler.to_string().replace("\"", ""),
             None => "ts-node".to_string()
         };
@@ -36,7 +36,7 @@ impl Interpreter for TypeScript_original {
             support_level,
             code: String::new(),
             main_file_path: mfp,
-            compiler
+            interpreter
         })
     }
 
@@ -123,7 +123,7 @@ impl Interpreter for TypeScript_original {
 
     fn execute(&mut self) -> Result<String, SniprunError> {
         //run th binary and get the std output (or stderr)
-        let interpreter = TypeScript_original::get_interpreter_or(&self.data, &self.compiler);
+        let interpreter = TypeScript_original::get_interpreter_or(&self.data, &self.interpreter);
         let output = Command::new(interpreter.split_whitespace().next().unwrap())
             .args(interpreter.split_whitespace().skip(1))
             .arg(&self.main_file_path)

--- a/src/interpreters/TypeScript_original.rs
+++ b/src/interpreters/TypeScript_original.rs
@@ -7,6 +7,9 @@ pub struct TypeScript_original {
     data: DataHolder,
     code: String,
     main_file_path: String,
+
+    //specific to Typescript
+    compiler: String,
 }
 
 impl ReplLikeInterpreter for TypeScript_original {}
@@ -23,11 +26,17 @@ impl Interpreter for TypeScript_original {
 
         //pre-create string pointing to main file's and binary's path
         let mfp = lwd + "/main.ts";
+
+        let compiler = match TypeScript_original::get_interpreter_option(&data, "compiler") {
+            Some(user_compiler) => user_compiler.to_string().replace("\"", ""),
+            None => "ts-node".to_string()
+        };
         Box::new(TypeScript_original {
             data,
             support_level,
             code: String::new(),
             main_file_path: mfp,
+            compiler
         })
     }
 
@@ -114,7 +123,7 @@ impl Interpreter for TypeScript_original {
 
     fn execute(&mut self) -> Result<String, SniprunError> {
         //run th binary and get the std output (or stderr)
-        let interpreter = TypeScript_original::get_interpreter_or(&self.data, "ts-node");
+        let interpreter = TypeScript_original::get_interpreter_or(&self.data, &self.compiler);
         let output = Command::new(interpreter.split_whitespace().next().unwrap())
             .args(interpreter.split_whitespace().skip(1))
             .arg(&self.main_file_path)


### PR DESCRIPTION
If you are using NodeJS v22+ you no longer need to use ts-node, simply running `node main.ts` is enough to run the code.
I've taken an approach where ts-node is still the default solution

More info here: 
https://nodejs.org/en/learn/typescript/run-natively
https://medium.com/@itxdeeni/a-new-era-for-typescript-with-node-js-v22-7-x-say-goodbye-to-ts-node-54c91a02eb0b