### PR TITLE
fix: check window validity before closing sniprun terminal

### DIFF
--- a/lua/sniprun/display.lua
+++ b/lua/sniprun/display.lua
@@ -150,7 +150,10 @@ function M.term_close()
     if M.term.window_handle == 0 then
         return
     end
-    vim.api.nvim_win_close(M.term.window_handle, true)
+    if vim.api.nvim_win_is_valid(M.term.window_handle) then
+        vim.api.nvim_win_close(M.term.window_handle, true)
+    end
+
     M.term.window_handle = 0
     M.term.buffer = -1
     M.term.current_line = 0


### PR DESCRIPTION
Problem: Neovim crashes on exit with error E5108: Invalid window id when using sniprun with terminal display mode.

Error message:
```
Error in QuitPre Autocommands for "?*"..function Sniprun_close_term_on_leave:
  E5108: Lua: .../sniprun/lua/sniprun/display.lua:153: Invalid window id: 1001
  stack traceback:
          [C]: in function 'nvim_win_close'
          .../sniprun/lua/sniprun/display.lua:153: in function 'term_close'
```

Fix: Add nvim_win_is_valid() check before calling nvim_win_close() in the term_close() function (display.lua:153).

Steps to reproduce:
  1. Configure sniprun with terminal display
  2. Run code snippet to open terminal window
  3. Close window and exit neovim
  4. Error appears
  
  Fixes #322 
